### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/BluetoothLeGatt/gradle/wrapper/gradle-wrapper.properties
+++ b/BluetoothLeGatt/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-rc-1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update gradle-wrapper.properties to fix "Invalid Gradle JDK configuration found"