### PR TITLE
ACCESS_FINE_LOCATION Permission

### DIFF
--- a/BluetoothLeGatt/Application/src/main/AndroidManifest.xml
+++ b/BluetoothLeGatt/Application/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+ 
+    <!-- Required only if your app isn't using the Device Companion Manager. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
Because this example doesn't use yet the [Companion device pairing](https://developer.android.com/guide/topics/connectivity/companion-device-pairing) API's, we need then ACCESS_FINE_LOCATION permission to scan, otherwise scanning is always empty.