### PR TITLE
Use the binding view for updates.  

### DIFF
--- a/BluetoothAdvertisementsKotlin/app/src/main/java/com/example/bluetoothadvertisements/MainActivity.kt
+++ b/BluetoothAdvertisementsKotlin/app/src/main/java/com/example/bluetoothadvertisements/MainActivity.kt
@@ -35,10 +35,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-        setSupportActionBar(findViewById(R.id.toolbar))
-
         binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         if (savedInstanceState == null) {
             verifyBluetoothCapabilities()


### PR DESCRIPTION
Use the binding view for updates.

Toolbar was removed in https://github.com/android/connectivity-samples/commit/56828c5616ebe8c5347c70a93a0f3601c763eea6#diff-74c58200a5aa5c8f7ba40fd553f036b6ab2111c0b121506a2b9ea46800965a0dL25 and replaced by FrameLayout, no need to setSupportActionbar if the toolbar does not exist any more.