### PR TITLE
Changed debug log in onStartFailure method of DeviceAdvertiseCallback

### DIFF
--- a/BluetoothLeChat/app/src/main/java/com/example/bluetoothlechat/bluetooth/ChatServer.kt
+++ b/BluetoothLeChat/app/src/main/java/com/example/bluetoothlechat/bluetooth/ChatServer.kt
@@ -301,10 +301,7 @@ object ChatServer {
     private class DeviceAdvertiseCallback : AdvertiseCallback() {
         override fun onStartFailure(errorCode: Int) {
             super.onStartFailure(errorCode)
-            // Send error state to display
-            val errorMessage = "Advertise failed with error: $errorCode"
-            Log.d(TAG, "Advertising failed")
-            //_viewState.value = DeviceScanViewState.Error(errorMessage)
+            Log.d(TAG, "Advertising failed with error: $errorCode")
         }
 
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {


### PR DESCRIPTION
The onStartFailure method of DeviceAdvertiseCallback was containing unused/commented code and not printing the errorCode to log.