### PR TITLE
UWB Dependencies Update

### DIFF
--- a/UwbRanging/app/build.gradle
+++ b/UwbRanging/app/build.gradle
@@ -78,7 +78,7 @@ android {
 
 dependencies {
     implementation project(path: ':uwbranging')
-    implementation 'androidx.core.uwb:uwb:1.0.0-alpha03'
+    implementation 'androidx.core.uwb:uwb:1.0.0-alpha04'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation 'androidx.activity:activity-compose:1.6.0'

--- a/UwbRanging/uwbranging/build.gradle
+++ b/UwbRanging/uwbranging/build.gradle
@@ -61,7 +61,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core.uwb:uwb:1.0.0-alpha03'
+    implementation 'androidx.core.uwb:uwb:1.0.0-alpha04'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.test:core:1.5.0-alpha02'


### PR DESCRIPTION
- Updated to December 7, 2022 version `1.0.0-alpha04` for `androidx.core.uwb:uwb`

- Tested OK with the **latest current Beta release** of Google Play Services `23.04.13` (_February 1st, 2023_)