### PR TITLE
Add share button and share functionality.

### DIFF
--- a/NearbyConnectionsWalkieTalkie/app/src/main/AndroidManifest.xml
+++ b/NearbyConnectionsWalkieTalkie/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="32" />

--- a/NearbyConnectionsWalkieTalkie/app/src/main/res/layout/activity_main.xml
+++ b/NearbyConnectionsWalkieTalkie/app/src/main/res/layout/activity_main.xml
@@ -44,4 +44,18 @@
         android:textSize="20sp"
         android:textColor="@color/textColor" />
 
+    <Button
+        android:id="@+id/button_share"
+        style="@android:style/Widget.Material.Button.Colored"
+        android:layout_width="173dp"
+        android:layout_height="93dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="120dp"
+        android:enabled="false"
+        android:gravity="center_horizontal|center_vertical"
+        android:text="@string/button_share"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+        android:visibility="visible"
+        tools:visibility="visible" />
+
 </FrameLayout>

--- a/NearbyConnectionsWalkieTalkie/app/src/main/res/values/strings.xml
+++ b/NearbyConnectionsWalkieTalkie/app/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
 
     <string name="status_unknown">Please wait</string>
     <string name="status_connected">Connected\nHold any of the volume keys to talk</string>
+
+    <string name="button_share">Share</string>
 </resources>


### PR DESCRIPTION
Added share button and implemented share functionality.
The sharing button becomes enabled when the connection is established and is disabled otherwise.
I've added permissions to external storage as a quick way to save files to Downloads folder. In a real environment, of course, I would have to add system file picker (as per Android guidelines).
The functionality itself is added by adding intent which opens the same MainActivity and modifies it's state by adding payloads which are subsequently sent when connection is established. It's not an ideal solution, but making it better requires introducing new activity and sharing context between MainActivity and a new one and would require more time to complete.